### PR TITLE
Add Arbitrum Rinkeby Network

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -120,6 +120,14 @@ export const NETWORKS: Record<string, Network> = {
     emoji: '🔵',
     chainId: '42161',
   },
+  arbutrum_testnet: {
+    title: 'Arbitrum Testnet',
+    rpcUrl: 'https://rinkeby.arbitrum.io/rpc',
+    explorerUrl: 'https://testnet.arbiscan.io/',
+    explorerApiUrl: 'https://api-testnet.arbiscan.io/api',
+    emoji: '🧪',
+    chainId: '421611'
+  },
   moon_river: {
     title: 'Moonriver',
     rpcUrl: 'https://rpc.moonriver.moonbeam.network',


### PR DESCRIPTION
- Adds arbitrum rinkeby to louper
- Not sure if this will work, I couldn't fully test bc I don't have supabase env vars set up on my local
- Here is a arbitrum rinkeby diamond address to test with: [`0xDcDa0B216267290a3a65Ff2d23713DB5eB1Ecc96` ](https://testnet.arbiscan.io/address/0xdcda0b216267290a3a65ff2d23713db5eb1ecc96)

**Note:** arbiscan API key is the same for the testnet and mainnet