### PR TITLE
Recognize Events in the ABI

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -38,6 +38,24 @@ export const getFacetMethods = (address: string, abi: any): Method[] => {
   return methods
 }
 
+export const getABIMethods = (address: string, abi: any): string => {
+  const contract = new ethers.Contract(address, abi)
+
+  const methods: Method[] = []
+  const events = contract.interface.events
+  for (const [f, val] of Object.entries(events)) {
+    const selector = utils.keccak256(utils.toUtf8Bytes(f)).substr(0, 10)
+
+    const method: Method = {
+      signature: f,
+      selector,
+      fragment: val,
+    }
+    methods.push(method)
+  }
+  return methods
+}
+
 export const shortProfile = (address: string) => {
   return `${address.substring(0, 5)}-${address.substring(address.length - 5)}`
 }


### PR DESCRIPTION
In the old version events were not recognized when building the complete ABI, only the functions were. I've modified the script to recognize those + it ignores duplicate events as well.

However, it comes with a small caveat: there is no way of knowing whether an event belongs to an outdated facet (provided its signature is unique). I don't know how to mitigate this, yet. Any ideas?