### PR TITLE
chore: adding Energy Web chains

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -213,7 +213,7 @@ export const NETWORKS: Record<string, Network> = {
     rpcUrl: 'https://rpc.energyweb.org',
     explorerUrl: 'http://explorer.energyweb.org',
     explorerApiUrl: 'https://explorer.energyweb.org/api-docs',
-    emoji: '🟣',
+    emoji: '⚡',
     chainId: '246',
   },
   volta: {
@@ -221,7 +221,7 @@ export const NETWORKS: Record<string, Network> = {
     rpcUrl: 'https://volta-rpc.energyweb.org',
     explorerUrl: 'http://volta-explorer.energyweb.org',
     explorerApiUrl: 'https://volta-explorer.energyweb.org/api-docs',
-    emoji: '🟣',
+    emoji: '⚡',
     chainId: '73799',
   },
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -208,4 +208,20 @@ export const NETWORKS: Record<string, Network> = {
     emoji: '🟩',
     chainId: '1088',
   },
+  ewc: {
+    title: 'Energy Web Chain',
+    rpcUrl: 'https://rpc.energyweb.org',
+    explorerUrl: 'http://explorer.energyweb.org',
+    explorerApiUrl: 'https://explorer.energyweb.org/api-docs',
+    emoji: '🟣',
+    chainId: '246',
+  },
+  volta: {
+    title: 'Volta - Energy Web Testnet',
+    rpcUrl: 'https://volta-rpc.energyweb.org',
+    explorerUrl: 'http://volta-explorer.energyweb.org',
+    explorerApiUrl: 'https://volta-explorer.energyweb.org/api-docs',
+    emoji: '🟣',
+    chainId: '73799',
+  },
 }


### PR DESCRIPTION
This PR adds two chains to the networks configuration.
Those are [Energyweb foundation](https://www.energyweb.org/)'s chains, both mainnet (EWC) and testnet (volta).

This addition will help Energyweb foundation with the testings, verification and deployment of their diamond proxy-based projects