### PR TITLE
Updated Mumbai RPC

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -56,7 +56,7 @@ export const NETWORKS: Record<string, Network> = {
   },
   mumbai: {
     title: 'Polygon Mumbai Testnet',
-    rpcUrl: 'https://matic-mumbai.chainstacklabs.com/',
+    rpcUrl: 'https://rpc-mumbai.maticvigil.com/',
     explorerUrl: 'https://mumbai.polygonscan.com/',
     explorerApiUrl: 'https://api-testnet.polygonscan.com/api',
     emoji: '🧪',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,15 @@ export const NETWORKS: Record<string, Network> = {
     chainId: '1',
     txHistorySupported: true,
   },
+  ganache: {
+    title: 'Ganache Testnet',
+    rpcUrl: 'http://127.0.0.1:8545/',
+    explorerUrl: '',
+    explorerApiUrl: '',
+    emoji: '🔮',
+    chainId: '1337',
+    txHistorySupported: true,
+  },
   goerli: {
     title: 'Goerli Testnet',
     rpcUrl: 'https://rpc.ankr.com/eth_goerli',


### PR DESCRIPTION
Updated Mumbai rpc to https://rpc-mumbai.maticvigil.com/
Removed Dead RPC link